### PR TITLE
Add an initial issue template and configuration.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ROS Answers
+    about: Get help with individual issues or questions from the ROS community.
+    url: https://answers.ros.org
+  - name: Open Robotics Security
+    about: Please report vulnerabilities to Open Robotics projects or infrastructure here.
+    url: mailto:security@openrobotics.org

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -3,6 +3,3 @@ contact_links:
   - name: ROS Answers
     about: Get help with individual issues or questions from the ROS community.
     url: https://answers.ros.org
-  - name: Open Robotics Security
-    about: Please report vulnerabilities to Open Robotics projects or infrastructure here.
-    url: mailto:security@openrobotics.org

--- a/.github/ISSUE_TEMPLATE/infrastructure.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure.md
@@ -16,3 +16,7 @@ Example: When running `apt update` the following output appears
 W: GPG error: http://packages.ros.org/ros/ubuntu focal InRelease: The following signatures were invalid: EXPKEYSIG F42ED6FBAB17C654 Open Robotics <info@osrfoundation.org>
 E: The repository 'http://packages.ros.org/ros/ubuntu focal InRelease' is not signed.
 ```
+
+### Security issues
+
+If you have a security issue to report please do so via email to <security@openrobotics.org>.

--- a/.github/ISSUE_TEMPLATE/infrastructure.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure.md
@@ -7,6 +7,7 @@ about: Report an issue with Open Robotics infrastructure
 - [ ] I have checked [ROS Answers](https://answers.ros.org) for similar reports and solutions.
 - [ ] I have checked the [ROS Status page](https://status.ros.org) and my issue is not listed there.
 - [ ] I have checked the [open issues](https://github.com/osrf/infrastructure/issues) for similar reports.
+- [ ] This is **not** a [security issue](https://github.com/osrf/infrastructure/blob/latest/SECURITY.md) If you have a security issue to report please do so via email to <security@openrobotics.org>.
 
 ## Problem description
 
@@ -16,7 +17,3 @@ Example: When running `apt update` the following output appears
 W: GPG error: http://packages.ros.org/ros/ubuntu focal InRelease: The following signatures were invalid: EXPKEYSIG F42ED6FBAB17C654 Open Robotics <info@osrfoundation.org>
 E: The repository 'http://packages.ros.org/ros/ubuntu focal InRelease' is not signed.
 ```
-
-### Security issues
-
-If you have a security issue to report please do so via email to <security@openrobotics.org>.

--- a/.github/ISSUE_TEMPLATE/infrastructure.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure.md
@@ -1,0 +1,16 @@
+---
+name: Infrastructure Issue
+about: Report an issue with Open Robotics infrastructure
+
+---
+
+- [ ] I have checked the [ROS Status page](https://status.ros.org) and my issue is not listed there.
+
+## Problem description
+
+Example: When running `apt update` the following output appears
+
+```
+W: GPG error: http://packages.ros.org/ros/ubuntu focal InRelease: The following signatures were invalid: EXPKEYSIG F42ED6FBAB17C654 Open Robotics <info@osrfoundation.org>
+E: The repository 'http://packages.ros.org/ros/ubuntu focal InRelease' is not signed.
+```

--- a/.github/ISSUE_TEMPLATE/infrastructure.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure.md
@@ -4,7 +4,9 @@ about: Report an issue with Open Robotics infrastructure
 
 ---
 
+- [ ] I have checked [ROS Answers](https://answers.ros.org) for similar reports and solutions.
 - [ ] I have checked the [ROS Status page](https://status.ros.org) and my issue is not listed there.
+- [ ] I have checked the [open issues](https://github.com/osrf/infrastructure/issues) for similar reports.
 
 ## Problem description
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting security issues to Open Robotics
+
+To report security issues to Open Robotics regarding Open Robotics software or infrastructure please send your report via email to <security@openrobotics.org>.
+
+For reporting issues related to ROS 2 common packages please see [REP-2006](https://ros.org/reps/rep-2006.html).


### PR DESCRIPTION
I set up the configuration and template below using GitHub documentation [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) and [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates). The initial template is bare and generic but if we start here we can create more focused templates going forward.