### PR TITLE
Update support links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ROS Answers
-    about: Get help with individual issues or questions from the ROS community.
-    url: https://answers.ros.org
+  - name: Robotics StackExchange
+    about: Get help with individual issues or questions from the Robotics community.
+    url: https://robotics.stackexchange.com/

--- a/.github/ISSUE_TEMPLATE/infrastructure.md
+++ b/.github/ISSUE_TEMPLATE/infrastructure.md
@@ -4,8 +4,8 @@ about: Report an issue with Open Robotics infrastructure
 
 ---
 
-- [ ] I have checked [ROS Answers](https://answers.ros.org) for similar reports and solutions.
-- [ ] I have checked the [ROS Status page](https://status.ros.org) and my issue is not listed there.
+- [ ] I have checked [Robotics StackExchange](https://robotics.stackexchange.com/) for similar reports and solutions.
+- [ ] I have checked the [Open Robotics Status page](https://status.openrobotics.org) and my issue is not listed there.
 - [ ] I have checked the [open issues](https://github.com/osrf/infrastructure/issues) for similar reports.
 - [ ] This is **not** a [security issue](https://github.com/osrf/infrastructure/blob/latest/SECURITY.md) If you have a security issue to report please do so via email to <security@openrobotics.org>.
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Managed projects include
 * [ROS package index](https://index.ros.org)
 
 Before reporting issues here please check
-* [ROS Answers](https://answers.ros.org) for help with questions or problems that may be specific to your usage.
-* [ROS Status page](https://status.ros.org) for information on the published status of ROS infrastructure.
+* [Robotics Stack Exchange](https://robotics.stackexchange.com) for help with questions or problems that may be specific to your usage.
+* [Open Robotics Status page](https://status.openrobotics.org) for information on the published status of OSRF infrastructure.
 * [Open issues on osrf/infrastructure](https://github.com/osrf/infrastructure/issues) in case the problem you are reporting has already been reported.
 
 If your issue is not found please follow the template instructions to [open a new issue](https://github.com/osrf/infrastructure/issues/new/choose).


### PR DESCRIPTION
ROS Answers and the ROS Status Page have been retired in favor of StackExchange and status.openrobotics.org.